### PR TITLE
ENH: make nessai_gw logger a child of the nessai logger

### DIFF
--- a/src/nessai_gw/__init__.py
+++ b/src/nessai_gw/__init__.py
@@ -7,4 +7,7 @@ except PackageNotFoundError:
     # package is not installed
     __version__ = "unknown"
 
-logging.getLogger(__name__).addHandler(logging.NullHandler())
+nessai_logger = logging.getLogger("nessai")
+# logger is called 'nessai.nessai_gw'
+# This ensures the logging changes propagate to loggers in this package.
+nessai_logger.getChild(__name__)

--- a/src/nessai_gw/proposals.py
+++ b/src/nessai_gw/proposals.py
@@ -2,16 +2,16 @@
 """
 Specific proposal methods for sampling gravitational-wave models.
 """
-import logging
 from nessai.proposal import (
     AugmentedFlowProposal,
     FlowProposal,
 )
 from nessai.experimental.proposal.clustering import ClusteringFlowProposal
 
+from . import nessai_logger
 from .reparameterisations.utils import get_reparameterisation
 
-logger = logging.getLogger(__name__)
+logger = nessai_logger.getChild(__name__)
 
 
 class GWFlowProposal(FlowProposal):
@@ -69,7 +69,7 @@ class GWFlowProposal(FlowProposal):
             if n not in self._reparameterisation.parameters
         ]
         logger.info(f"Adding default reparameterisations for {parameters}")
-
+        print(logger, logger.parent)
         for p in parameters:
             logger.debug(f"Trying to add reparameterisation for {p}")
             if p in self._reparameterisation.parameters:

--- a/src/nessai_gw/reparameterisations/distance.py
+++ b/src/nessai_gw/reparameterisations/distance.py
@@ -1,13 +1,13 @@
-import logging
 from nessai.reparameterisations import (
     RescaleToBounds,
 )
 from nessai.priors import log_uniform_prior
 
 from .distance_converters import get_distance_converter
+from .. import nessai_logger
 
 
-logger = logging.getLogger(__name__)
+logger = nessai_logger.getChild(__name__)
 
 
 class DistanceReparameterisation(RescaleToBounds):

--- a/src/nessai_gw/reparameterisations/distance_converters.py
+++ b/src/nessai_gw/reparameterisations/distance_converters.py
@@ -7,7 +7,9 @@ import logging
 import numpy as np
 from scipy import interpolate
 
-logger = logging.getLogger(__name__)
+from .. import nessai_logger
+
+logger = nessai_logger.getChild(__name__)
 
 try:
     from astropy import cosmology as cosmo

--- a/src/nessai_gw/reparameterisations/phase.py
+++ b/src/nessai_gw/reparameterisations/phase.py
@@ -1,11 +1,12 @@
-import logging
 from nessai.reparameterisations import (
     Reparameterisation,
 )
 import numpy as np
 
+from .. import nessai_logger
 
-logger = logging.getLogger(__name__)
+
+logger = nessai_logger.getChild(__name__)
 
 
 class DeltaPhaseReparameterisation(Reparameterisation):


### PR DESCRIPTION
This change ensures that the logging level/handlers from `nessai` are propagated through to this package.